### PR TITLE
Refine GPU DVFS debug logging

### DIFF
--- a/drivers/gpu/arm/exynos/frontend/gpex_clock_sysfs.c
+++ b/drivers/gpu/arm/exynos/frontend/gpex_clock_sysfs.c
@@ -18,6 +18,8 @@
  * http://www.gnu.org/licenses/gpl-2.0.html.
  */
 
+#include <linux/printk.h>
+
 #include <gpex_clock.h>
 #include <gpex_pm.h>
 #include <gpex_dvfs.h>
@@ -167,6 +169,12 @@ GPEX_STATIC ssize_t set_max_lock_dvfs(const char *buf, size_t count)
 			return -ENOENT;
 		}
 
+		if (clock > gpex_clock_get_max_clock_limit()) {
+			pr_info("[gpex_clock_sysfs] max lock request %d clamped to %d\n",
+				clock, gpex_clock_get_max_clock_limit());
+			clock = gpex_clock_get_max_clock_limit();
+		}
+
 		if (clock == gpex_clock_get_max_clock())
 			gpex_clock_lock_clock(GPU_CLOCK_MAX_UNLOCK, SYSFS_LOCK, 0);
 		else
@@ -261,8 +269,11 @@ GPEX_STATIC ssize_t set_min_lock_dvfs(const char *buf, size_t count)
 			return -ENOENT;
 		}
 
-		if (clock > gpex_clock_get_max_clock_limit())
+		if (clock > gpex_clock_get_max_clock_limit()) {
+			pr_info("[gpex_clock_sysfs] min lock request %d clamped to %d\n",
+				clock, gpex_clock_get_max_clock_limit());
 			clock = gpex_clock_get_max_clock_limit();
+		}
 
 		if (clock == gpex_clock_get_min_clock())
 			gpex_clock_lock_clock(GPU_CLOCK_MIN_UNLOCK, SYSFS_LOCK, 0);
@@ -355,8 +366,11 @@ GPEX_STATIC ssize_t set_mm_min_lock_dvfs(const char *buf, size_t count)
 			return -ENOENT;
 		}
 
-		if (clock > gpex_clock_get_max_clock_limit())
+		if (clock > gpex_clock_get_max_clock_limit()) {
+			pr_info("[gpex_clock_sysfs] MM min lock request %d clamped to %d\n",
+				clock, gpex_clock_get_max_clock_limit());
 			clock = gpex_clock_get_max_clock_limit();
+		}
 
 		gpex_clboost_set_state(CLBOOST_DISABLE);
 

--- a/drivers/soc/samsung/cal-if/cal-if.c
+++ b/drivers/soc/samsung/cal-if/cal-if.c
@@ -1,5 +1,6 @@
 #include <linux/module.h>
 #include <linux/debug-snapshot.h>
+#include <linux/printk.h>
 #include <soc/samsung/ect_parser.h>
 #include <soc/samsung/cal-if.h>
 #ifdef CONFIG_EXYNOS9820_BTS
@@ -349,7 +350,7 @@ void cal_dfs_set_volt_margin(unsigned int id, int volt)
 }
 
 int cal_dfs_get_rate_asv_table(unsigned int id,
-					struct dvfs_rate_volt *table)
+				       struct dvfs_rate_volt *table)
 {
 	unsigned long rate[48];
 	unsigned int volt[48];
@@ -357,11 +358,19 @@ int cal_dfs_get_rate_asv_table(unsigned int id,
 	int idx;
 
 	num_of_entry = cal_dfs_get_rate_table(id, rate);
-	if (num_of_entry == 0)
+	if (num_of_entry == 0) {
+		pr_info("[cal-if] id %x reported 0 rate entries\n", id);
 		return 0;
+	}
 
-	if (num_of_entry != cal_dfs_get_asv_table(id, volt))
+	if (num_of_entry != cal_dfs_get_asv_table(id, volt)) {
+		pr_info("[cal-if] id %x rate/asv count mismatch (%d)\n",
+			id, num_of_entry);
 		return 0;
+	}
+
+	pr_info("[cal-if] id %x exporting %d rate/asv entries\n",
+		id, num_of_entry);
 
 	for (idx = 0; idx < num_of_entry; idx++) {
 		table[idx].rate = rate[idx];


### PR DESCRIPTION
## Summary
- expand CAL rate export logging to report mismatches and entry counts
- add backend and frontend GPU DVFS traces for level counts, clamps, and lock transitions
- clamp sysfs lock requests to CAL limits with explicit printk diagnostics