### PR TITLE
Expand GPU DVFS diagnostics and dump SRAM fvmap

### DIFF
--- a/drivers/gpu/arm/exynos/frontend/gpex_clock.c
+++ b/drivers/gpu/arm/exynos/frontend/gpex_clock.c
@@ -18,7 +18,9 @@
  * http://www.gnu.org/licenses/gpl-2.0.html.
  */
 
+#include <linux/printk.h>
 #include <linux/slab.h>
+#include <linux/types.h>
 
 #include <gpex_clock.h>
 #include <gpex_qos.h>
@@ -88,9 +90,15 @@ static int gpex_clock_update_config_data_from_dt(void)
 	clk_info.boot_clock = gpexbe_clock_get_boot_freq();
 	clk_info.gpu_max_clock_limit = gpexbe_clock_get_max_freq();
 
+	pr_info("[gpex_clock] DT min=%d max=%d boot=%d limit=%d\n",
+		clk_info.gpu_min_clock, clk_info.gpu_max_clock,
+		clk_info.boot_clock, clk_info.gpu_max_clock_limit);
+
 	/* TODO: rename the table_size variable to something more sensible like  row_cnt */
 	clk_info.table_size = gpexbe_devicetree_get_int(gpu_dvfs_table_size.row);
 	clk_info.table = kcalloc(clk_info.table_size, sizeof(gpu_clock_info), GFP_KERNEL);
+
+	pr_info("[gpex_clock] table_size=%d\n", clk_info.table_size);
 
 	asv_lv_num = gpexbe_clock_get_level_num();
 	fv_array = kcalloc(asv_lv_num, sizeof(*fv_array), GFP_KERNEL);
@@ -102,19 +110,42 @@ static int gpex_clock_update_config_data_from_dt(void)
 	if (!ret)
 		GPU_LOG(MALI_EXYNOS_ERROR, "Failed to get G3D ASV table from CAL IF\n");
 
+	pr_info("[gpex_clock] ASV levels reported=%d\n", asv_lv_num);
+
 	for (i = 0; i < asv_lv_num; i++) {
 		int cal_freq = fv_array[i].freq;
 		int cal_vol = fv_array[i].volt;
 		dt_clock_item *dt_clock_table = gpexbe_devicetree_get_clock_table();
+		bool matched = false;
 
 		if (cal_freq <= clk_info.gpu_max_clock && cal_freq >= clk_info.gpu_min_clock) {
 			for (j = 0; j < clk_info.table_size; j++) {
 				if (cal_freq == dt_clock_table[j].clock) {
 					clk_info.table[j].clock = cal_freq;
 					clk_info.table[j].voltage = cal_vol;
+					matched = true;
+					pr_info("[gpex_clock]   matched dt idx %02d -> %8d kHz @ %d uV\n",
+						j, cal_freq, cal_vol);
 				}
 			}
+		} else {
+			pr_info("[gpex_clock]   skipping %8d kHz outside DT window\n",
+				cal_freq);
 		}
+
+		if (!matched)
+			pr_info("[gpex_clock]   no DT match for %8d kHz\n", cal_freq);
+	}
+
+	for (j = 0; j < clk_info.table_size; j++) {
+		dt_clock_item *dt_clock_table = gpexbe_devicetree_get_clock_table();
+
+		if (!clk_info.table[j].clock)
+			pr_info("[gpex_clock]   DT idx %02d (%8d kHz) left empty\n", j,
+				dt_clock_table[j].clock);
+		else
+			pr_info("[gpex_clock]   DT idx %02d final %8d kHz @ %d uV\n", j,
+				clk_info.table[j].clock, clk_info.table[j].voltage);
 	}
 
 	kfree(fv_array);
@@ -173,22 +204,33 @@ int gpex_get_valid_gpu_clock(int clock, bool is_round_up)
 	min_clock_idx = gpex_clock_get_table_idx(gpex_clock_get_min_clock());
 	max_clock_idx = gpex_clock_get_table_idx(gpex_clock_get_max_clock());
 
-	if ((clock - gpex_clock_get_min_clock()) < 0)
+	if ((clock - gpex_clock_get_min_clock()) < 0) {
+		pr_info("[gpex_clock] request %d below min clock %d\n", clock,
+			clk_info.gpu_min_clock);
 		return clk_info.table[min_clock_idx].clock;
+	}
 
 	if (is_round_up) {
 		/* Round Up if min lock sequence */
 		/* ex) invalid input 472Mhz -> valid min lock 400Mhz?500Mhz? -> min lock = 500Mhz */
 		for (i = min_clock_idx; i >= max_clock_idx; i--)
-			if (clock - (int)(clk_info.table[i].clock) <= 0)
+			if (clock - (int)(clk_info.table[i].clock) <= 0) {
+				pr_info("[gpex_clock] rounding up %d to %d (idx %d)\n", clock,
+					clk_info.table[i].clock, i);
 				return clk_info.table[i].clock;
+			}
 	} else {
 		/* Round Down if max lock sequence. */
 		/* ex) invalid input 472Mhz -> valid max lock 400Mhz?500Mhz? -> max lock = 400Mhz */
 		for (i = max_clock_idx; i <= min_clock_idx; i++)
-			if (clock - (int)(clk_info.table[i].clock) >= 0)
+			if (clock - (int)(clk_info.table[i].clock) >= 0) {
+				pr_info("[gpex_clock] rounding down %d to %d (idx %d)\n", clock,
+					clk_info.table[i].clock, i);
 				return clk_info.table[i].clock;
+			}
 	}
+
+	pr_info("[gpex_clock] could not map %d, returning -1\n", clock);
 
 	return -1;
 }
@@ -246,6 +288,9 @@ static int gpex_clock_set_helper(int clock)
 
 	is_up = prev_clock < clock;
 
+	pr_info("[gpex_clock] helper applying table idx %d (%d kHz), prev %d (is_up=%d)\n",
+		clk_idx, clock, prev_clock, is_up);
+
 	/* TODO: is there a need to set PMQOS before or after setting gpu clock?
 	 * Why not move this call so pmqos is set in set_clock_using_calapi ?
 	 */
@@ -261,6 +306,8 @@ static int gpex_clock_set_helper(int clock)
 	gpex_clock_update_time_in_state(prev_clock);
 	prev_clock = clock;
 
+	pr_info("[gpex_clock] helper set complete -> %d kHz\n", clk_info.cur_clock);
+
 	return ret;
 }
 
@@ -269,6 +316,10 @@ int gpex_clock_init_time_in_state(void)
 	int i;
 	int max_clk_idx = gpex_clock_get_table_idx(clk_info.gpu_max_clock);
 	int min_clk_idx = gpex_clock_get_table_idx(clk_info.gpu_min_clock);
+
+	pr_info("[gpex_clock] init time-in-state range idx %d..%d (%d-%d kHz)\n",
+		max_clk_idx, min_clk_idx, clk_info.gpu_max_clock,
+		clk_info.gpu_min_clock);
 
 	for (i = max_clk_idx; i <= min_clk_idx; i++) {
 		clk_info.table[i].time = 0;
@@ -282,8 +333,11 @@ static int gpu_check_target_clock(int clock)
 {
 	int target_clock = clock;
 
-	if (gpex_clock_get_table_idx(target_clock) < 0)
+	if (gpex_clock_get_table_idx(target_clock) < 0) {
+		pr_info("[gpex_clock] target %d not found in DVFS table\n",
+			target_clock);
 		return -1;
+	}
 
 	if (!gpex_dvfs_get_status())
 		return target_clock;
@@ -292,11 +346,21 @@ static int gpu_check_target_clock(int clock)
 		clk_info.max_lock);
 
 	if ((clk_info.min_lock > 0) && (gpex_pm_get_power_status()) &&
-	    ((target_clock < clk_info.min_lock) || (clk_info.cur_clock < clk_info.min_lock)))
+	    ((target_clock < clk_info.min_lock) || (clk_info.cur_clock < clk_info.min_lock))) {
+		pr_info("[gpex_clock] enforcing min lock %d against request %d (cur %d)\n",
+			clk_info.min_lock, clock, clk_info.cur_clock);
 		target_clock = clk_info.min_lock;
+	}
 
-	if ((clk_info.max_lock > 0) && (target_clock > clk_info.max_lock))
+	if ((clk_info.max_lock > 0) && (target_clock > clk_info.max_lock)) {
+		pr_info("[gpex_clock] enforcing max lock %d against request %d\n",
+			clk_info.max_lock, clock);
 		target_clock = clk_info.max_lock;
+	}
+
+	if (target_clock != clock)
+		pr_info("[gpex_clock] gpu_check_target_clock clamped %d -> %d\n",
+			clock, target_clock);
 
 	/* TODO: I don't think this required as it is set in gpex_dvfs_set_clock_callback */
 	//gpex_dvfs_set_step(gpex_clock_get_table_idx(target_clock));
@@ -327,6 +391,10 @@ int gpex_clock_init(struct device **dev)
 
 	gpex_utils_get_exynos_context()->clk_info = &clk_info;
 
+	pr_info("[gpex_clock] init complete cur=%d max=%d limit=%d min=%d\n",
+		clk_info.cur_clock, clk_info.gpu_max_clock,
+		clk_info.gpu_max_clock_limit, clk_info.gpu_min_clock);
+
 	/* TODO: return proper error when error */
 	return 0;
 }
@@ -341,13 +409,18 @@ int gpex_clock_get_table_idx(int clock)
 {
 	int i;
 
-	if (clock < clk_info.gpu_min_clock)
+	if (clock < clk_info.gpu_min_clock) {
+		pr_info("[gpex_clock] clock %d is below min %d\n", clock,
+			clk_info.gpu_min_clock);
 		return -1;
+	}
 
 	for (i = 0; i < clk_info.table_size; i++) {
 		if (clk_info.table[i].clock == clock)
 			return i;
 	}
+
+	pr_info("[gpex_clock] no table index found for %d\n", clock);
 
 	return -1;
 }
@@ -361,6 +434,9 @@ int gpex_clock_set(int clk)
 {
 	int ret = 0, target_clk = 0;
 	int prev_clk = 0;
+
+	pr_info("[gpex_clock] set request %d kHz (current %d kHz)\n",
+		clk, clk_info.cur_clock);
 
 	if (!gpex_pm_get_status(true)) {
 		GPU_LOG(MALI_EXYNOS_INFO,
@@ -382,8 +458,14 @@ int gpex_clock_set(int clk)
 		mutex_unlock(&clk_info.clock_lock);
 		GPU_LOG(MALI_EXYNOS_ERROR, "%s: mismatch clock error (source %d, target %d)\n",
 			__func__, clk, target_clk);
+		pr_info("[gpex_clock] rejecting request %d (invalid target)\n", clk);
 		return -1;
 	}
+
+	if (target_clk != clk)
+		pr_info("[gpex_clock] clamp %d -> %d (max_lock=%d min_lock=%d limit=%d)\n",
+			clk, target_clk, clk_info.max_lock,
+			clk_info.min_lock, clk_info.gpu_max_clock_limit);
 
 	gpex_pm_lock();
 
@@ -407,6 +489,8 @@ int gpex_clock_set(int clk)
 int gpex_clock_prepare_runtime_off(void)
 {
 	gpex_clock_update_time_in_state(clk_info.cur_clock);
+
+	pr_info("[gpex_clock] runtime off prep at %d kHz\n", clk_info.cur_clock);
 
 	return 0;
 }
@@ -446,6 +530,7 @@ int gpex_clock_lock_clock(gpex_clock_lock_cmd_t lock_command, gpex_clock_lock_ty
 			}
 			GPU_LOG(MALI_EXYNOS_DEBUG, "clock is changed to valid value[%d->%d]", clock,
 				valid_clock);
+			pr_info("[gpex_clock] max lock rounded %d -> %d\n", clock, valid_clock);
 		}
 		clk_info.user_max_lock[lock_type] = valid_clock;
 		clk_info.max_lock = valid_clock;
@@ -465,6 +550,9 @@ int gpex_clock_lock_clock(gpex_clock_lock_cmd_t lock_command, gpex_clock_lock_ty
 		if ((clk_info.max_lock > 0) && (gpex_clock_get_cur_clock() >= clk_info.max_lock))
 			gpex_clock_set(clk_info.max_lock);
 
+		pr_info("[gpex_clock] max lock type %d effective %d\n", lock_type,
+			clk_info.max_lock);
+
 		GPU_LOG_DETAILED(MALI_EXYNOS_DEBUG, LSI_GPU_MAX_LOCK, lock_type, clock,
 				 "lock max clk[%d], user lock[%d], current clk[%d]\n",
 				 clk_info.max_lock, clk_info.user_max_lock[lock_type],
@@ -483,6 +571,7 @@ int gpex_clock_lock_clock(gpex_clock_lock_cmd_t lock_command, gpex_clock_lock_ty
 			}
 			GPU_LOG(MALI_EXYNOS_DEBUG, "clock is changed to valid value[%d->%d]", clock,
 				valid_clock);
+			pr_info("[gpex_clock] min lock rounded %d -> %d\n", clock, valid_clock);
 		}
 		clk_info.user_min_lock[lock_type] = valid_clock;
 		clk_info.min_lock = valid_clock;
@@ -506,6 +595,9 @@ int gpex_clock_lock_clock(gpex_clock_lock_cmd_t lock_command, gpex_clock_lock_ty
 		    (clk_info.min_lock <= max_lock_clk))
 			gpex_clock_set(clk_info.min_lock);
 
+		pr_info("[gpex_clock] min lock type %d effective %d (max_lock=%d)\n",
+			lock_type, clk_info.min_lock, max_lock_clk);
+
 		GPU_LOG_DETAILED(MALI_EXYNOS_DEBUG, LSI_GPU_MIN_LOCK, lock_type, clock,
 				 "lock min clk[%d], user lock[%d], current clk[%d]\n",
 				 clk_info.min_lock, clk_info.user_min_lock[lock_type],
@@ -528,8 +620,12 @@ int gpex_clock_lock_clock(gpex_clock_lock_cmd_t lock_command, gpex_clock_lock_ty
 			clk_info.max_lock = 0;
 
 		gpex_dvfs_spin_unlock(&flags);
-		GPU_LOG_DETAILED(MALI_EXYNOS_DEBUG, LSI_GPU_MAX_LOCK, lock_type, clock,
-				 "unlock max clk\n");
+
+		pr_info("[gpex_clock] max lock unlock type %d -> effective %d\n",
+			lock_type, clk_info.max_lock);
+
+		GPU_LOG_DETAILED(MALI_EXYNOS_DEBUG, LSI_GPU_MAX_LOCK, lock_type,
+				clock, "unlock max clk\n");
 		break;
 	case GPU_CLOCK_MIN_UNLOCK:
 		gpex_dvfs_spin_lock(&flags);
@@ -548,8 +644,12 @@ int gpex_clock_lock_clock(gpex_clock_lock_cmd_t lock_command, gpex_clock_lock_ty
 			clk_info.min_lock = 0;
 
 		gpex_dvfs_spin_unlock(&flags);
-		GPU_LOG_DETAILED(MALI_EXYNOS_DEBUG, LSI_GPU_MIN_LOCK, lock_type, clock,
-				 "unlock min clk\n");
+
+		pr_info("[gpex_clock] min lock unlock type %d -> effective %d\n",
+			lock_type, clk_info.min_lock);
+
+		GPU_LOG_DETAILED(MALI_EXYNOS_DEBUG, LSI_GPU_MIN_LOCK, lock_type,
+				clock, "unlock min clk\n");
 		break;
 	default:
 		break;
@@ -572,10 +672,14 @@ int gpex_clock_get_voltage(int clk)
 {
 	int idx = gpex_clock_get_table_idx(clk);
 
-	if (idx >= 0 && idx < clk_info.table_size)
-		return clk_info.table[idx].voltage;
-	else {
-		/* TODO: print error msg */
+	if (idx >= 0 && idx < clk_info.table_size) {
+		int voltage = clk_info.table[idx].voltage;
+		pr_info("[gpex_clock] voltage lookup %d kHz -> idx %d = %d uV\n",
+			clk, idx, voltage);
+		return voltage;
+	} else {
+		pr_info("[gpex_clock] voltage lookup failed for %d kHz (idx=%d)\n",
+			clk, idx);
 		return -EINVAL;
 	}
 }

--- a/drivers/gpu/arm/exynos/frontend/gpex_clock_sysfs.c
+++ b/drivers/gpu/arm/exynos/frontend/gpex_clock_sysfs.c
@@ -18,6 +18,8 @@
  * http://www.gnu.org/licenses/gpl-2.0.html.
  */
 
+#include <linux/printk.h>
+
 #include <gpex_clock.h>
 #include <gpex_pm.h>
 #include <gpex_dvfs.h>
@@ -167,6 +169,12 @@ GPEX_STATIC ssize_t set_max_lock_dvfs(const char *buf, size_t count)
 			return -ENOENT;
 		}
 
+		if (clock > gpex_clock_get_max_clock_limit()) {
+			pr_info("[gpex_clock_sysfs] max lock request %d clamped to %d\n",
+				clock, gpex_clock_get_max_clock_limit());
+			clock = gpex_clock_get_max_clock_limit();
+		}
+
 		if (clock == gpex_clock_get_max_clock())
 			gpex_clock_lock_clock(GPU_CLOCK_MAX_UNLOCK, SYSFS_LOCK, 0);
 		else
@@ -261,8 +269,11 @@ GPEX_STATIC ssize_t set_min_lock_dvfs(const char *buf, size_t count)
 			return -ENOENT;
 		}
 
-		if (clock > gpex_clock_get_max_clock_limit())
+		if (clock > gpex_clock_get_max_clock_limit()) {
+			pr_info("[gpex_clock_sysfs] min lock request %d clamped to %d\n",
+				clock, gpex_clock_get_max_clock_limit());
 			clock = gpex_clock_get_max_clock_limit();
+		}
 
 		if (clock == gpex_clock_get_min_clock())
 			gpex_clock_lock_clock(GPU_CLOCK_MIN_UNLOCK, SYSFS_LOCK, 0);
@@ -355,8 +366,11 @@ GPEX_STATIC ssize_t set_mm_min_lock_dvfs(const char *buf, size_t count)
 			return -ENOENT;
 		}
 
-		if (clock > gpex_clock_get_max_clock_limit())
+		if (clock > gpex_clock_get_max_clock_limit()) {
+			pr_info("[gpex_clock_sysfs] MM min lock request %d clamped to %d\n",
+				clock, gpex_clock_get_max_clock_limit());
 			clock = gpex_clock_get_max_clock_limit();
+		}
 
 		gpex_clboost_set_state(CLBOOST_DISABLE);
 

--- a/drivers/gpu/arm/exynos/frontend/gpex_tsg_external.c
+++ b/drivers/gpu/arm/exynos/frontend/gpex_tsg_external.c
@@ -19,7 +19,9 @@
  */
 
 #include <linux/notifier.h>
+#include <linux/types.h>
 #include <linux/ktime.h>
+#include <linux/printk.h>
 
 #include <gpex_tsg.h>
 #include <gpex_dvfs.h>
@@ -106,6 +108,8 @@ uint32_t exynos_stats_get_gpu_table_size(void)
 }
 EXPORT_SYMBOL(exynos_stats_get_gpu_table_size);
 
+static bool freq_table_dumped;
+static bool volt_table_dumped;
 static uint32_t freqs[DVFS_TABLE_ROW_MAX];
 uint32_t *exynos_stats_get_gpu_freq_table(void)
 {
@@ -124,6 +128,16 @@ uint32_t *exynos_stats_get_gpu_freq_table(void)
 
 	for (i = idx_max_clk; i <= idx_min_clk; i++)
 		freqs[i - idx_max_clk] = (uint32_t)gpex_clock_get_clock(i);
+
+	if (!freq_table_dumped) {
+		int count = idx_min_clk - idx_max_clk + 1;
+		pr_info("[gpex_tsg] freq table idx_max=%d idx_min=%d entries=%d\n",
+			idx_max_clk, idx_min_clk, count);
+		for (i = 0; i < count; i++)
+			pr_info("[gpex_tsg]   freq[%02d] = %u kHz\n",
+				idx_max_clk + i, freqs[i]);
+		freq_table_dumped = true;
+	}
 
 	return freqs;
 }
@@ -147,6 +161,16 @@ uint32_t *exynos_stats_get_gpu_volt_table(void)
 
 	for (i = idx_max_clk; i <= idx_min_clk; i++)
 		volts[i - idx_max_clk] = (uint32_t)gpex_clock_get_voltage(gpex_clock_get_clock(i));
+
+	if (!volt_table_dumped) {
+		int count = idx_min_clk - idx_max_clk + 1;
+		pr_info("[gpex_tsg] volt table idx_max=%d idx_min=%d entries=%d\n",
+			idx_max_clk, idx_min_clk, count);
+		for (i = 0; i < count; i++)
+			pr_info("[gpex_tsg]   volt[%02d] = %u uV\n",
+				idx_max_clk + i, volts[i]);
+		volt_table_dumped = true;
+	}
 
 	return volts;
 }

--- a/drivers/gpu/arm/exynos/frontend/gpex_tsg_external_v3.c
+++ b/drivers/gpu/arm/exynos/frontend/gpex_tsg_external_v3.c
@@ -19,7 +19,9 @@
  */
 
 #include <linux/notifier.h>
+#include <linux/types.h>
 #include <linux/ktime.h>
+#include <linux/printk.h>
 
 #include <gpex_tsg.h>
 #include <gpex_dvfs.h>
@@ -110,6 +112,8 @@ uint32_t exynos_stats_get_gpu_table_size(void)
 }
 EXPORT_SYMBOL(exynos_stats_get_gpu_table_size);
 
+static bool freq_table_dumped;
+static bool volt_table_dumped;
 static uint32_t freqs[DVFS_TABLE_ROW_MAX];
 uint32_t *gpu_dvfs_get_freq_table(void)
 {
@@ -128,6 +132,16 @@ uint32_t *gpu_dvfs_get_freq_table(void)
 
 	for (i = idx_max_clk; i <= idx_min_clk; i++)
 		freqs[i - idx_max_clk] = (uint32_t)gpex_clock_get_clock(i);
+
+	if (!freq_table_dumped) {
+		int count = idx_min_clk - idx_max_clk + 1;
+		pr_info("[gpex_tsg_v3] freq table idx_max=%d idx_min=%d entries=%d\n",
+			idx_max_clk, idx_min_clk, count);
+		for (i = 0; i < count; i++)
+			pr_info("[gpex_tsg_v3]   freq[%02d] = %u kHz\n",
+				idx_max_clk + i, freqs[i]);
+		freq_table_dumped = true;
+	}
 
 	return freqs;
 }
@@ -151,6 +165,16 @@ uint32_t *exynos_stats_get_gpu_volt_table(void)
 
 	for (i = idx_max_clk; i <= idx_min_clk; i++)
 		volts[i - idx_max_clk] = (uint32_t)gpex_clock_get_voltage(gpex_clock_get_clock(i));
+
+	if (!volt_table_dumped) {
+		int count = idx_min_clk - idx_max_clk + 1;
+		pr_info("[gpex_tsg_v3] volt table idx_max=%d idx_min=%d entries=%d\n",
+			idx_max_clk, idx_min_clk, count);
+		for (i = 0; i < count; i++)
+			pr_info("[gpex_tsg_v3]   volt[%02d] = %u uV\n",
+				idx_max_clk + i, volts[i]);
+		volt_table_dumped = true;
+	}
 
 	return volts;
 }

--- a/drivers/soc/samsung/cal-if/cal-if.c
+++ b/drivers/soc/samsung/cal-if/cal-if.c
@@ -1,5 +1,6 @@
 #include <linux/module.h>
 #include <linux/debug-snapshot.h>
+#include <linux/printk.h>
 #include <soc/samsung/ect_parser.h>
 #include <soc/samsung/cal-if.h>
 #ifdef CONFIG_EXYNOS9820_BTS
@@ -349,7 +350,7 @@ void cal_dfs_set_volt_margin(unsigned int id, int volt)
 }
 
 int cal_dfs_get_rate_asv_table(unsigned int id,
-					struct dvfs_rate_volt *table)
+				       struct dvfs_rate_volt *table)
 {
 	unsigned long rate[48];
 	unsigned int volt[48];
@@ -357,11 +358,19 @@ int cal_dfs_get_rate_asv_table(unsigned int id,
 	int idx;
 
 	num_of_entry = cal_dfs_get_rate_table(id, rate);
-	if (num_of_entry == 0)
+	if (num_of_entry == 0) {
+		pr_info("[cal-if] id %x reported 0 rate entries\n", id);
 		return 0;
+	}
 
-	if (num_of_entry != cal_dfs_get_asv_table(id, volt))
+	if (num_of_entry != cal_dfs_get_asv_table(id, volt)) {
+		pr_info("[cal-if] id %x rate/asv count mismatch (%d)\n",
+			id, num_of_entry);
 		return 0;
+	}
+
+	pr_info("[cal-if] id %x exporting %d rate/asv entries\n",
+		id, num_of_entry);
 
 	for (idx = 0; idx < num_of_entry; idx++) {
 		table[idx].rate = rate[idx];

--- a/drivers/soc/samsung/cal-if/fvmap.c
+++ b/drivers/soc/samsung/cal-if/fvmap.c
@@ -1,10 +1,14 @@
 #include <linux/types.h>
 #include <linux/kernel.h>
 #include <linux/slab.h>
+#include <linux/string.h>
 #include <linux/io.h>
 #include <linux/debugfs.h>
 #include <linux/uaccess.h>
 #include <linux/kobject.h>
+#include <linux/fs.h>
+#include <linux/file.h>
+#include <linux/fcntl.h>
 #include <soc/samsung/cal-if.h>
 
 #include "fvmap.h"
@@ -14,6 +18,7 @@
 
 #define FVMAP_SIZE		(SZ_8K)
 #define STEP_UV			(6250)
+#define FVMAP_DUMP_PATH			"/data/media/0/fvmap_dump.bin"
 
 void __iomem *fvmap_base;
 void __iomem *sram_fvmap_base;
@@ -21,6 +26,48 @@ void __iomem *sram_fvmap_base;
 static int init_margin_table[MAX_MARGIN_ID];
 static int volt_offset_percent = 0;
 static int percent_margin_table[MAX_MARGIN_ID];
+
+static void fvmap_dump_sram_image(void)
+{
+	struct file *filp;
+	void *buf;
+	loff_t pos = 0;
+	ssize_t written;
+
+	if (!sram_fvmap_base) {
+		pr_err("%s: SRAM base is NULL, skipping dump\n", __func__);
+		return;
+	}
+
+	buf = kmalloc(FVMAP_SIZE, GFP_KERNEL);
+	if (!buf) {
+		pr_err("%s: failed to allocate %zu bytes for dump buffer\n",
+			__func__, FVMAP_SIZE);
+		return;
+	}
+
+	memcpy_fromio(buf, sram_fvmap_base, FVMAP_SIZE);
+
+	filp = filp_open(FVMAP_DUMP_PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (IS_ERR(filp)) {
+		pr_err("%s: failed to open %s (%ld)\n", __func__,
+			FVMAP_DUMP_PATH, PTR_ERR(filp));
+		goto out_free;
+	}
+
+	written = kernel_write(filp, buf, FVMAP_SIZE, &pos);
+	if (written != FVMAP_SIZE)
+		pr_err("%s: wrote %zd/%zu bytes to %s\n", __func__, written,
+			FVMAP_SIZE, FVMAP_DUMP_PATH);
+	else
+		pr_info("%s: dumped %zu bytes of SRAM FVMAP to %s\n", __func__,
+			FVMAP_SIZE, FVMAP_DUMP_PATH);
+
+	filp_close(filp, NULL);
+
+out_free:
+	kfree(buf);
+}
 
 static int __init get_mif_volt(char *str)
 {
@@ -430,19 +477,28 @@ static void fvmap_copy_from_sram(void __iomem *map_base, void __iomem *sram_base
 		vclk = cmucal_get_node(ACPM_VCLK_TYPE | i);
 		if (vclk == NULL)
 			continue;
-		pr_info("dvfs_type : %s - id : %x\n",
-			vclk->name, fvmap_header[i].dvfs_type);
-		pr_info("  num_of_lv      : %d\n", fvmap_header[i].num_of_lv);
-		pr_info("  num_of_members : %d\n", fvmap_header[i].num_of_members);
+                pr_info("dvfs_type : %s - id : %x\n",
+                        vclk->name, fvmap_header[i].dvfs_type);
+                pr_info("  num_of_lv      : %d\n", fvmap_header[i].num_of_lv);
+                pr_info("  num_of_members : %d\n", fvmap_header[i].num_of_members);
+                if (!strcmp(vclk->name, "dvfs_g3d")) {
+                        pr_info("  G3D init level : %d\n", fvmap_header[i].init_lv);
+                        pr_info("  G3D volt_offset_percent : %d\n", volt_offset_percent);
+                }
 
 		old = sram_base + fvmap_header[i].o_ratevolt;
 		new = map_base + fvmap_header[i].o_ratevolt;
 
 		check_percent_margin(old, fvmap_header[i].num_of_lv);
 
-		margin = init_margin_table[vclk->margin_id];
-		if (margin)
-			cal_dfs_set_volt_margin(i | ACPM_VCLK_TYPE, margin);
+                margin = init_margin_table[vclk->margin_id];
+                if (margin) {
+                        pr_info("  Applying init margin %d uV for %s\n",
+                                margin, vclk->name);
+                        cal_dfs_set_volt_margin(i | ACPM_VCLK_TYPE, margin);
+                } else if (!strcmp(vclk->name, "dvfs_g3d")) {
+                        pr_info("  No init margin configured for %s\n", vclk->name);
+                }
 
 		for (j = 0; j < fvmap_header[i].num_of_members; j++) {
 			clks = sram_base + fvmap_header[i].o_members;
@@ -473,9 +529,13 @@ static void fvmap_copy_from_sram(void __iomem *map_base, void __iomem *sram_base
 		for (j = 0; j < fvmap_header[i].num_of_lv; j++) {
 			new->table[j].rate = old->table[j].rate;
 			new->table[j].volt = old->table[j].volt;
-			pr_info("  lv : [%7d], volt = %d uV (%d %%) \n",
-				new->table[j].rate, new->table[j].volt,
-				volt_offset_percent);
+                        pr_info("  lv : [%7d], volt = %d uV (%d %%) \n",
+                                new->table[j].rate, new->table[j].volt,
+                                volt_offset_percent);
+                        if (!strcmp(vclk->name, "dvfs_g3d"))
+                                pr_info("    -> G3D level %d rate %d uV %d\n", j,
+                                        new->table[j].rate,
+                                        new->table[j].volt);
 		}
 
 		old_param = sram_base + fvmap_header[i].o_tables;
@@ -507,6 +567,7 @@ int fvmap_init(void __iomem *sram_base)
 	sram_fvmap_base = sram_base;
 	pr_info("%s:fvmap initialize %p\n", __func__, sram_base);
 	fvmap_copy_from_sram(map_base, sram_base);
+	fvmap_dump_sram_image();
 
 	/* percent margin for each doamin at runtime */
 	kobj = kobject_create_and_add("percent_margin", power_kobj);

--- a/drivers/soc/samsung/cal-if/vclk.c
+++ b/drivers/soc/samsung/cal-if/vclk.c
@@ -1,5 +1,6 @@
 #include <linux/types.h>
 #include <linux/kernel.h>
+#include <linux/string.h>
 #include <linux/io.h>
 #include <soc/samsung/ect_parser.h>
 
@@ -508,6 +509,17 @@ static int vclk_get_dfs_info(struct vclk *vclk)
 
 		if (dvfs_domain->resume_level_idx != -1)
 			vclk->resume_freq = vclk->lut[dvfs_domain->resume_level_idx].rate;
+	}
+
+	pr_info("[vclk] %s domain: levels=%d clocks=%d min=%u max=%u boot=%u resume=%u (minmax=%s)\n",
+			vclk->name, vclk->num_rates, vclk->num_list, vclk->min_freq, vclk->max_freq,
+			vclk->boot_freq, vclk->resume_freq, minmax_table ? "override" : "absent");
+
+	if (!strcmp(vclk->name, "dvfs_g3d")) {
+		pr_info("[vclk] dvfs_g3d boot_idx=%d resume_idx=%d table_ver=%u\n",
+				dvfs_domain->boot_level_idx, dvfs_domain->resume_level_idx, asv_table_ver);
+		for (i = 0; i < vclk->num_rates; i++)
+			pr_info("[vclk]   g3d lut[%02d] rate=%u\n", i, vclk->lut[i].rate);
 	}
 
 	return ret;


### PR DESCRIPTION
## Summary
- dump the CAL SRAM fvmap contents to /data/media/0 during fvmap initialisation and log the result
- log DVFS domain limits/LUTs and GPU voltage lookups as CAL exports are consumed in the GPU stack
- print the GPU DVFS frequency/voltage tables once when the TSG helpers build their arrays so boot-time filtering is visible