### PR TITLE
Log fvmap SRAM blob and seed GPU OC slot

### DIFF
--- a/drivers/gpu/arm/exynos/frontend/gpex_tsg_external.c
+++ b/drivers/gpu/arm/exynos/frontend/gpex_tsg_external.c
@@ -19,7 +19,9 @@
  */
 
 #include <linux/notifier.h>
+#include <linux/types.h>
 #include <linux/ktime.h>
+#include <linux/printk.h>
 
 #include <gpex_tsg.h>
 #include <gpex_dvfs.h>
@@ -106,6 +108,8 @@ uint32_t exynos_stats_get_gpu_table_size(void)
 }
 EXPORT_SYMBOL(exynos_stats_get_gpu_table_size);
 
+static bool freq_table_dumped;
+static bool volt_table_dumped;
 static uint32_t freqs[DVFS_TABLE_ROW_MAX];
 uint32_t *exynos_stats_get_gpu_freq_table(void)
 {
@@ -124,6 +128,16 @@ uint32_t *exynos_stats_get_gpu_freq_table(void)
 
 	for (i = idx_max_clk; i <= idx_min_clk; i++)
 		freqs[i - idx_max_clk] = (uint32_t)gpex_clock_get_clock(i);
+
+	if (!freq_table_dumped) {
+		int count = idx_min_clk - idx_max_clk + 1;
+		pr_info("[gpex_tsg] freq table idx_max=%d idx_min=%d entries=%d\n",
+			idx_max_clk, idx_min_clk, count);
+		for (i = 0; i < count; i++)
+			pr_info("[gpex_tsg]   freq[%02d] = %u kHz\n",
+				idx_max_clk + i, freqs[i]);
+		freq_table_dumped = true;
+	}
 
 	return freqs;
 }
@@ -147,6 +161,16 @@ uint32_t *exynos_stats_get_gpu_volt_table(void)
 
 	for (i = idx_max_clk; i <= idx_min_clk; i++)
 		volts[i - idx_max_clk] = (uint32_t)gpex_clock_get_voltage(gpex_clock_get_clock(i));
+
+	if (!volt_table_dumped) {
+		int count = idx_min_clk - idx_max_clk + 1;
+		pr_info("[gpex_tsg] volt table idx_max=%d idx_min=%d entries=%d\n",
+			idx_max_clk, idx_min_clk, count);
+		for (i = 0; i < count; i++)
+			pr_info("[gpex_tsg]   volt[%02d] = %u uV\n",
+				idx_max_clk + i, volts[i]);
+		volt_table_dumped = true;
+	}
 
 	return volts;
 }

--- a/drivers/gpu/arm/exynos/frontend/gpex_tsg_external_v3.c
+++ b/drivers/gpu/arm/exynos/frontend/gpex_tsg_external_v3.c
@@ -19,7 +19,9 @@
  */
 
 #include <linux/notifier.h>
+#include <linux/types.h>
 #include <linux/ktime.h>
+#include <linux/printk.h>
 
 #include <gpex_tsg.h>
 #include <gpex_dvfs.h>
@@ -110,6 +112,8 @@ uint32_t exynos_stats_get_gpu_table_size(void)
 }
 EXPORT_SYMBOL(exynos_stats_get_gpu_table_size);
 
+static bool freq_table_dumped;
+static bool volt_table_dumped;
 static uint32_t freqs[DVFS_TABLE_ROW_MAX];
 uint32_t *gpu_dvfs_get_freq_table(void)
 {
@@ -128,6 +132,16 @@ uint32_t *gpu_dvfs_get_freq_table(void)
 
 	for (i = idx_max_clk; i <= idx_min_clk; i++)
 		freqs[i - idx_max_clk] = (uint32_t)gpex_clock_get_clock(i);
+
+	if (!freq_table_dumped) {
+		int count = idx_min_clk - idx_max_clk + 1;
+		pr_info("[gpex_tsg_v3] freq table idx_max=%d idx_min=%d entries=%d\n",
+			idx_max_clk, idx_min_clk, count);
+		for (i = 0; i < count; i++)
+			pr_info("[gpex_tsg_v3]   freq[%02d] = %u kHz\n",
+				idx_max_clk + i, freqs[i]);
+		freq_table_dumped = true;
+	}
 
 	return freqs;
 }
@@ -151,6 +165,16 @@ uint32_t *exynos_stats_get_gpu_volt_table(void)
 
 	for (i = idx_max_clk; i <= idx_min_clk; i++)
 		volts[i - idx_max_clk] = (uint32_t)gpex_clock_get_voltage(gpex_clock_get_clock(i));
+
+	if (!volt_table_dumped) {
+		int count = idx_min_clk - idx_max_clk + 1;
+		pr_info("[gpex_tsg_v3] volt table idx_max=%d idx_min=%d entries=%d\n",
+			idx_max_clk, idx_min_clk, count);
+		for (i = 0; i < count; i++)
+			pr_info("[gpex_tsg_v3]   volt[%02d] = %u uV\n",
+				idx_max_clk + i, volts[i]);
+		volt_table_dumped = true;
+	}
 
 	return volts;
 }

--- a/drivers/soc/samsung/cal-if/cal-if.c
+++ b/drivers/soc/samsung/cal-if/cal-if.c
@@ -1,5 +1,6 @@
 #include <linux/module.h>
 #include <linux/debug-snapshot.h>
+#include <linux/printk.h>
 #include <soc/samsung/ect_parser.h>
 #include <soc/samsung/cal-if.h>
 #ifdef CONFIG_EXYNOS9820_BTS
@@ -349,7 +350,7 @@ void cal_dfs_set_volt_margin(unsigned int id, int volt)
 }
 
 int cal_dfs_get_rate_asv_table(unsigned int id,
-					struct dvfs_rate_volt *table)
+				       struct dvfs_rate_volt *table)
 {
 	unsigned long rate[48];
 	unsigned int volt[48];
@@ -357,11 +358,19 @@ int cal_dfs_get_rate_asv_table(unsigned int id,
 	int idx;
 
 	num_of_entry = cal_dfs_get_rate_table(id, rate);
-	if (num_of_entry == 0)
+	if (num_of_entry == 0) {
+		pr_info("[cal-if] id %x reported 0 rate entries\n", id);
 		return 0;
+	}
 
-	if (num_of_entry != cal_dfs_get_asv_table(id, volt))
+	if (num_of_entry != cal_dfs_get_asv_table(id, volt)) {
+		pr_info("[cal-if] id %x rate/asv count mismatch (%d)\n",
+			id, num_of_entry);
 		return 0;
+	}
+
+	pr_info("[cal-if] id %x exporting %d rate/asv entries\n",
+		id, num_of_entry);
 
 	for (idx = 0; idx < num_of_entry; idx++) {
 		table[idx].rate = rate[idx];

--- a/drivers/soc/samsung/cal-if/vclk.c
+++ b/drivers/soc/samsung/cal-if/vclk.c
@@ -1,5 +1,6 @@
 #include <linux/types.h>
 #include <linux/kernel.h>
+#include <linux/string.h>
 #include <linux/io.h>
 #include <soc/samsung/ect_parser.h>
 
@@ -509,6 +510,19 @@ static int vclk_get_dfs_info(struct vclk *vclk)
 		if (dvfs_domain->resume_level_idx != -1)
 			vclk->resume_freq = vclk->lut[dvfs_domain->resume_level_idx].rate;
 	}
+
+        pr_info("[G3D][VCLK] %s domain: levels=%d clocks=%d min=%u max=%u boot=%u resume=%u (minmax=%s)\n",
+                vclk->name, vclk->num_rates, vclk->num_list, vclk->min_freq,
+                vclk->max_freq, vclk->boot_freq, vclk->resume_freq,
+                minmax_table ? "override" : "absent");
+
+        if (!strcmp(vclk->name, "dvfs_g3d")) {
+                pr_info("[G3D][VCLK] boot_idx=%d resume_idx=%d table_ver=%u\n",
+                        dvfs_domain->boot_level_idx, dvfs_domain->resume_level_idx,
+                        asv_table_ver);
+                for (i = 0; i < vclk->num_rates; i++)
+                        pr_info("[G3D][VCLK]   lut[%02d] rate=%u\n", i, vclk->lut[i].rate);
+        }
 
 	return ret;
 err_nomem2:


### PR DESCRIPTION
## Summary
- log the complete SRAM fvmap image during fvmap copy so boot logs carry the raw firmware blob
- inject a 754000 kHz / 725000 uV fallback entry into the GPU DVFS table when the DT slot is empty to keep the custom level visible