### PR TITLE
Ensure GPU min lock is reapplied after runtime resume

### DIFF
--- a/drivers/gpu/arm/exynos/frontend/gpex_clock.c
+++ b/drivers/gpu/arm/exynos/frontend/gpex_clock.c
@@ -456,6 +456,30 @@ int gpex_clock_get_clock_slow(void)
 	return gpexbe_clock_get_rate();
 }
 
+void gpex_clock_sync_min_lock_on_resume(void)
+{
+	int min_lock;
+	int hw_clock;
+	bool power_on;
+
+	min_lock = gpex_clock_get_min_lock();
+	if (min_lock <= 0)
+		return;
+
+	gpex_pm_lock();
+	power_on = gpex_pm_get_status(false);
+	hw_clock = power_on ? gpex_clock_get_clock_slow() : 0;
+	gpex_pm_unlock();
+
+	if (!power_on)
+		return;
+
+	if ((hw_clock > 0) && (hw_clock >= min_lock))
+		return;
+
+	gpex_clock_set(min_lock);
+}
+
 int gpex_clock_set(int clk)
 {
 	int ret = 0, target_clk = 0;

--- a/drivers/gpu/arm/exynos/frontend/gpex_pm.c
+++ b/drivers/gpu/arm/exynos/frontend/gpex_pm.c
@@ -326,6 +326,8 @@ int gpex_pm_runtime_on_prepare(struct device *dev)
 
 	gpexwa_wakeup_clock_restore();
 
+	gpex_clock_sync_min_lock_on_resume();
+
 	return 0;
 }
 

--- a/drivers/gpu/arm/exynos/include/gpex_clock.h
+++ b/drivers/gpu/arm/exynos/include/gpex_clock.h
@@ -88,6 +88,8 @@ int gpex_clock_prepare_runtime_off(void);
  */
 int gpex_clock_set(int clk);
 
+void gpex_clock_sync_min_lock_on_resume(void);
+
 /**
  * gpex_clock_lock_clock() - set GPU clock max or min lock
  * @lock_command: requested command max/min lock/unlock


### PR DESCRIPTION
## Summary
- add a helper to reapply the effective GPU minimum lock when the device resumes
- invoke the helper during runtime power-on so enforced minimum frequencies persist across power cycles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de93db55ec83259b766a4b133667d0