### PR TITLE
Add GitHub workflow for Beyond Kernel build

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -1,0 +1,55 @@
+name: Build Kernel
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            bc \
+            bison \
+            build-essential \
+            ccache \
+            clang \
+            cpio \
+            flex \
+            libelf-dev \
+            libncurses-dev \
+            libssl-dev \
+            lld \
+            llvm \
+            python3 \
+            rsync \
+            unzip \
+            wget \
+            zip \
+            zstd
+
+      - name: Build kernel
+        run: |
+          chmod +x build.sh
+          ./build.sh --model beyond --ksu y
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-build-beyond
+          path: |
+            build/out/**/zip/*.zip
+            build/out/**/boot.img
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ modules.builtin
 !.gitignore
 !.mailmap
 !.cocciconfig
+!.github
 
 #
 # Generated include files

--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+case "$MODEL" in
+    beyond)
+        MODEL="beyond1lte"
+        ;;
+esac
+
 echo "Preparing the build environment..."
 
 pushd $(dirname "$0") > /dev/null
@@ -67,6 +73,8 @@ if [ ! -f "$CLANG_DIR/bin/clang-18" ]; then
     echo "Cleaning up..."
     popd > /dev/null
 fi
+
+KERNEL_DEFCONFIG=exynos9820_defconfig
 
 MAKE_ARGS="
 LLVM=1 \


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the kernel with the `--model beyond --ksu y` flags and publishes artifacts
- allow the build script to treat the shorthand `beyond` model as the existing `beyond1lte` configuration and define the default defconfig name
- unignore the `.github` directory so the workflow file is tracked

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68df92c8d57483258e0a407d53a9185d