### PR TITLE
Adjust little thermal cooling maps to stop clamping cpufreq boosts

### DIFF
--- a/arch/arm64/boot/dts/exynos/exynos9820.dts
+++ b/arch/arm64/boot/dts/exynos/exynos9820.dts
@@ -5891,40 +5891,40 @@
 				};
 			};
 			cooling-maps {
-				map0 {
-				     trip = <&little_alert0>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map1 {
-				     trip = <&little_alert1>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-			       };
-				map2 {
-				     trip = <&little_alert2>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map3 {
-				     trip = <&little_alert3>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map4 {
-				     trip = <&little_alert4>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map5 {
-				     trip = <&little_alert5>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-			       };
-				map6 {
-				     trip = <&little_alert6>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map7 {
-				     trip = <&little_hot>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-			};
-		};
+                                map0 {
+                                        trip = <&little_alert0>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map1 {
+                                        trip = <&little_alert1>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map2 {
+                                        trip = <&little_alert2>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map3 {
+                                        trip = <&little_alert3>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map4 {
+                                        trip = <&little_alert4>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map5 {
+                                        trip = <&little_alert5>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map6 {
+                                        trip = <&little_alert6>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map7 {
+                                        trip = <&little_hot>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                        };
+                };
 
 		gpu_thermal: G3D {
 			zone_name  = "G3D_THERMAL";

--- a/arch/arm64/boot/dts/exynos/exynos9825-r.dts
+++ b/arch/arm64/boot/dts/exynos/exynos9825-r.dts
@@ -5857,40 +5857,40 @@
 				};
 			};
 			cooling-maps {
-				map0 {
-				     trip = <&little_alert0>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map1 {
-				     trip = <&little_alert1>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-			       };
-				map2 {
-				     trip = <&little_alert2>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map3 {
-				     trip = <&little_alert3>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map4 {
-				     trip = <&little_alert4>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map5 {
-				     trip = <&little_alert5>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-			       };
-				map6 {
-				     trip = <&little_alert6>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map7 {
-				     trip = <&little_hot>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-			};
-		};
+                                map0 {
+                                        trip = <&little_alert0>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map1 {
+                                        trip = <&little_alert1>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map2 {
+                                        trip = <&little_alert2>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map3 {
+                                        trip = <&little_alert3>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map4 {
+                                        trip = <&little_alert4>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map5 {
+                                        trip = <&little_alert5>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map6 {
+                                        trip = <&little_alert6>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map7 {
+                                        trip = <&little_hot>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                        };
+                };
 
 		gpu_thermal: G3D {
 			zone_name  = "G3D_THERMAL";

--- a/arch/arm64/boot/dts/exynos/exynos9825.dts
+++ b/arch/arm64/boot/dts/exynos/exynos9825.dts
@@ -5891,40 +5891,40 @@
 				};
 			};
 			cooling-maps {
-				map0 {
-				     trip = <&little_alert0>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map1 {
-				     trip = <&little_alert1>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-			       };
-				map2 {
-				     trip = <&little_alert2>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map3 {
-				     trip = <&little_alert3>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map4 {
-				     trip = <&little_alert4>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map5 {
-				     trip = <&little_alert5>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-			       };
-				map6 {
-				     trip = <&little_alert6>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-				map7 {
-				     trip = <&little_hot>;
-				     cooling-device = <&cpufreq_domain0 0 0>;
-				};
-			};
-		};
+                                map0 {
+                                        trip = <&little_alert0>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map1 {
+                                        trip = <&little_alert1>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map2 {
+                                        trip = <&little_alert2>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map3 {
+                                        trip = <&little_alert3>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map4 {
+                                        trip = <&little_alert4>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map5 {
+                                        trip = <&little_alert5>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map6 {
+                                        trip = <&little_alert6>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                                map7 {
+                                        trip = <&little_hot>;
+                                        cooling-device = <&cpufreq_domain0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+                                };
+                        };
+                };
 
 		gpu_thermal: G3D {
 			zone_name  = "G3D_THERMAL";


### PR DESCRIPTION
## Summary
- update the Exynos 9820/9825 little thermal cooling maps so they no longer force state 0
- use THERMAL_NO_LIMIT to let the cpufreq driver expose higher frequencies when thermals allow it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3ccaf5b6c8325886eaa80f99c6dac